### PR TITLE
Latest USAGE in README.md + Case-Insensitive Level Strings + Fix go.mod package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,22 +54,29 @@ USAGE:
    humanlog [global options] command [command options] [arguments...]
 
 VERSION:
-   0.6.0
+   0.7.0
 
 AUTHOR:
-  Antoine Grondin - <antoinegrondin@gmail.com>
+   Antoine Grondin <antoinegrondin@gmail.com>
 
 COMMANDS:
    help, h  Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
-   --skip '--skip option --skip option'   keys to skip when parsing a log entry
-   --keep '--keep option --keep option'   keys to keep when parsing a log entry
-   --sort-longest       sort by longest key after having sorted lexicographically
-   --skip-unchanged        skip keys that have the same value than the previous entry
-   --truncate           truncates values that are longer than --truncate-length
-   --truncate-length '15'     truncate values that are longer than this length
-   --help, -h           show help
-   --version, -v        print the version
+   --skip value                      keys to skip when parsing a log entry
+   --keep value                      keys to keep when parsing a log entry
+   --sort-longest                    sort by longest key after having sorted lexicographically
+   --skip-unchanged                  skip keys that have the same value than the previous entry
+   --truncate                        truncates values that are longer than --truncate-length
+   --truncate-length value           truncate values that are longer than this length (default: 15)
+   --color value                     specify color mode: auto, on/force, off (default: "auto")
+   --light-bg                        use black as the base foreground color (for terminals with light backgrounds)
+   --time-format value               output time format, see https://golang.org/pkg/time/ for details (default: "Jan _2 15:04:05")
+   --ignore-interrupts, -i           ignore interrupts
+   --message-fields value, -m value  Custom JSON fields to search for the log message. (i.e. mssge, data.body.message) [$HUMANLOG_MESSAGE_FIELDS]
+   --time-fields value, -t value     Custom JSON fields to search for the log time. (i.e. logtime, data.body.datetime) [$HUMANLOG_TIME_FIELDS]
+   --level-fields value, -l value    Custom JSON fields to search for the log level. (i.e. somelevel, data.level) [$HUMANLOG_LEVEL_FIELDS]
+   --help, -h                        show help
+   --version, -v                     print the version
 ```
 [l2met]: https://github.com/ryandotsmith/l2met

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/humanlogio/humanlog
+module github.com/johnwarden/humanlog
 
 go 1.19
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/johnwarden/humanlog
+module github.com/humanlogio/humanlog
 
 go 1.19
 

--- a/internal/pkg/sink/stdiosink/stdio.go
+++ b/internal/pkg/sink/stdiosink/stdio.go
@@ -155,7 +155,7 @@ func (std *Stdio) Receive(ev *model.Event) error {
 
 	lvl := strings.ToUpper(data.Level)[:imin(4, len(data.Level))]
 	var level string
-	switch data.Level {
+	switch strings.ToLower(data.Level) {
 	case "debug":
 		level = std.opts.Palette.DebugLevelColor.Sprint(lvl)
 	case "info":


### PR DESCRIPTION
Fantastic tool. I wasn't aware of all the commandline options until I installed it because the README.md is out-of date. 

Also my application has uppercase level strings (e.g. level=DEBUG). I had to make humanlog ignore the case of level strings to get the correct colors.