### PR TITLE
fix: create temporary files in same dir as end destination

### DIFF
--- a/internal/pkg/state/state.go
+++ b/internal/pkg/state/state.go
@@ -68,7 +68,8 @@ func WriteStateFile(path string, state *State) error {
 	if err != nil {
 		return fmt.Errorf("marshaling state file: %v", err)
 	}
-	newf, err := os.CreateTemp(os.TempDir(), "humanlog_statefile")
+
+	newf, err := os.CreateTemp(filepath.Dir(path), "humanlog_statefile")
 	if err != nil {
 		return fmt.Errorf("creating temporary file for statefile: %w", err)
 	}


### PR DESCRIPTION
To ensure that config and state files are mutated atomically, updates are done by creating a temporary file, writing the new content, and doing an `os.rename` call to replace the old file with the temporary file. However, until this commit, the temporary file was create in the OS' default temp dir. In some environment (Codespaces), this directory isn't on the same filesystem as the target file.

The solution is to create the temp file in the target directory. It might end up leaving some artifacts if the process were to die before cleaning it up, but that's better than failing on such a common case as having more multiple filesystems.

Fixes https://github.com/humanlogio/humanlog/issues/57