### PR TITLE
Support for unix int timestamps in string values

### DIFF
--- a/logfmt_handler.go
+++ b/logfmt_handler.go
@@ -57,6 +57,9 @@ func (h *LogfmtHandler) UnmarshalLogfmt(data []byte) bool {
 			val := dec.Value()
 			if h.Time.IsZero() {
 				foundTime := checkEachUntilFound(h.Opts.TimeFields, func(field string) bool {
+					if !bytes.Equal(key, []byte(field)) {
+						return false
+					}
 					time, ok := tryParseTime(string(val))
 					if ok {
 						h.Time = time

--- a/time_parse.go
+++ b/time_parse.go
@@ -1,6 +1,7 @@
 package humanlog
 
 import (
+	"strconv"
 	"time"
 )
 
@@ -46,24 +47,29 @@ func parseTimeFloat64(value float64) time.Time {
 func tryParseTime(value interface{}) (time.Time, bool) {
 	var t time.Time
 	var err error
-	switch value.(type) {
+	switch typedVal := value.(type) {
 	case string:
 		for _, layout := range formats {
-			t, err = time.Parse(layout, value.(string))
+			t, err = time.Parse(layout, typedVal)
 			if err == nil {
 				return t, true
 			}
 		}
+		// try to parse unix time number from string
+		floatVal, err := strconv.ParseFloat(typedVal, 64)
+		if err == nil {
+			return parseTimeFloat64(floatVal), true
+		}
 	case float32:
-		return parseTimeFloat64(float64(value.(float32))), true
+		return parseTimeFloat64(float64(typedVal)), true
 	case float64:
-		return parseTimeFloat64(value.(float64)), true
+		return parseTimeFloat64(typedVal), true
 	case int:
-		return parseTimeFloat64(float64(value.(int))), true
+		return parseTimeFloat64(float64(typedVal)), true
 	case int32:
-		return parseTimeFloat64(float64(value.(int32))), true
+		return parseTimeFloat64(float64(typedVal)), true
 	case int64:
-		return parseTimeFloat64(float64(value.(int64))), true
+		return parseTimeFloat64(float64(typedVal)), true
 	}
 	return t, false
 }

--- a/time_parse_test.go
+++ b/time_parse_test.go
@@ -1,7 +1,9 @@
 package humanlog
 
 import (
+	"fmt"
 	"testing"
+	"time"
 )
 
 func TestTimeParseFloat64(t *testing.T) {
@@ -33,4 +35,42 @@ func TestTimeParseFloat64(t *testing.T) {
 			t.Fatal(tm.UnixNano())
 		}
 	})
+}
+
+func TestTryParseFloatTime(t *testing.T) {
+	testTime := time.Now()
+
+	t.Run("microseconds", func(t *testing.T) {
+		actualTime, ok := tryParseTime(fmt.Sprintf("%d", testTime.UnixMicro()))
+		if !ok {
+			t.Fatal("time not parsed")
+		}
+
+		if actualTime.UnixMicro() != testTime.UnixMicro() {
+			t.Fatalf("time not equal: %d != %d", actualTime.UnixMicro(), testTime.UnixMicro())
+		}
+	})
+
+	t.Run("milliseconds", func(t *testing.T) {
+		actualTime, ok := tryParseTime(fmt.Sprintf("%d", testTime.UnixMilli()))
+		if !ok {
+			t.Fatal("time not parsed")
+		}
+
+		if actualTime.UnixMilli() != testTime.UnixMilli() {
+			t.Fatalf("time not equal: %d != %d", actualTime.UnixMilli(), testTime.UnixMilli())
+		}
+	})
+
+	t.Run("seconds", func(t *testing.T) {
+		actualTime, ok := tryParseTime(fmt.Sprintf("%d", testTime.Unix()))
+		if !ok {
+			t.Fatal("time not parsed")
+		}
+
+		if actualTime.Unix() != testTime.Unix() {
+			t.Fatalf("time not equal: %d != %d", actualTime.Unix(), testTime.Unix())
+		}
+	})
+
 }


### PR DESCRIPTION
Unix timestamps may come within string field for example in logback lib(widely used java) json formatter - [ch.qos.logback.contrib.json.classic.JsonLayout](https://github.com/qos-ch/logback-contrib/blob/master/json/classic/src/main/java/ch/qos/logback/contrib/json/classic/JsonLayout.java#L37)

This will try to parse number when no other time formats succeed