### PR TITLE
fix(scanner): bring up to Unix(0) if parsed timestamp is negative

### DIFF
--- a/json_handler.go
+++ b/json_handler.go
@@ -50,15 +50,6 @@ func searchJSON(kvs map[string]interface{}, fieldList []string, found func(key s
 	return false
 }
 
-func checkEachUntilFound(fieldList []string, found func(string) bool) bool {
-	for _, field := range fieldList {
-		if found(field) {
-			return true
-		}
-	}
-	return false
-}
-
 func (h *JSONHandler) clear() {
 	h.Level = ""
 	h.Time = time.Time{}

--- a/scanner.go
+++ b/scanner.go
@@ -80,3 +80,12 @@ func Scan(ctx context.Context, src io.Reader, sink sink.Sink, opts *HandlerOptio
 		return err
 	}
 }
+
+func checkEachUntilFound(fieldList []string, found func(string) bool) bool {
+	for _, field := range fieldList {
+		if found(field) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
this may be too blunt of a fix, i didn't research it much. a better fix would be figuring out why the json stack of connectrpc doesnt like negative seconds in Google's protobuf timestamps