### PR TITLE
make cross-platform EADDRINUSE check

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,7 @@ jobs:
         os:
         - ubuntu-latest
         - macos-latest
-        # - windows-latest
+        - windows-latest
 
     name: test
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,7 +17,7 @@ jobs:
         os:
         - ubuntu-latest
         - macos-latest
-        # - windows-latest
+        - windows-latest
 
     name: lint
     runs-on: ${{ matrix.os }}

--- a/cmd/humanlog/localhost.go
+++ b/cmd/humanlog/localhost.go
@@ -29,9 +29,9 @@ import (
 	"github.com/rs/cors"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
-	"golang.org/x/sys/unix"
 
 	// imported for side-effect
+	internal_errors "github.com/humanlogio/humanlog/internal/errors"
 	_ "github.com/humanlogio/humanlog/internal/memstorage"
 )
 
@@ -51,7 +51,7 @@ func isEADDRINUSE(err error) bool {
 	if !ok {
 		return false
 	}
-	return nserrno == unix.EADDRINUSE
+	return internal_errors.IsSocketInUse(nserrno)
 }
 
 func startLocalhostServer(

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/humanlogio/humanlog/internal/pkg/config"
@@ -38,6 +40,13 @@ func TestHarness(t *testing.T) {
 			if err != nil {
 				t.Fatalf("reading config: %v", err)
 			}
+
+			if runtime.GOOS == "windows" {
+				input = replaceCRLF(input, "\r\n", "\n")
+				want = replaceCRLF(want, "\r\n", "\n")
+				cfgjson = replaceCRLF(cfgjson, "\r\n", "\n")
+			}
+
 			var cfg config.Config
 			if err := json.Unmarshal(cfgjson, &cfg); err != nil {
 				t.Fatalf("unmarshaling config: %v", err)
@@ -107,6 +116,11 @@ func TestHarness(t *testing.T) {
 
 type byteranges struct {
 	ranges []*byterange
+}
+
+func replaceCRLF(org []byte, oldCRLF string, newCRLF string) []byte {
+	replaced := strings.ReplaceAll(string(org), oldCRLF, newCRLF)
+	return []byte(replaced)
 }
 
 func newByteRanges() *byteranges {

--- a/internal/errors/errors_unix.go
+++ b/internal/errors/errors_unix.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package errors
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func IsSocketInUse(errno syscall.Errno) bool {
+	return errno == unix.EADDRINUSE
+}

--- a/internal/errors/errors_windows.go
+++ b/internal/errors/errors_windows.go
@@ -1,0 +1,13 @@
+//go:build windows
+
+package errors
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+func IsSocketInUse(errno syscall.Errno) bool {
+	return errno == windows.WSAEADDRINUSE
+}


### PR DESCRIPTION
### Summary of Works
1. add new package `errors` under the `internal` package.
2. create two files `errors_unix.go` and `errors_windows.go` and define function `IsSocketInUse` in each file.
3. add build constraint `go:build !windows` to `errors_unix.go` and `go:build windows` to `errors_windows.go`.
the function `isEADDRINUSE` now works on Windows 