### PR TITLE
feat(scanner): dynamic reordering of successful matchers

### DIFF
--- a/optimize.go
+++ b/optimize.go
@@ -1,0 +1,17 @@
+package humanlog
+
+// moveToFront moves the element at index `i` to the front
+// of the slice
+func moveToFront[El any](i int, s []El) []El {
+	if i == 0 {
+		return s
+	}
+	el := s[i]
+	for j := i; j > 0; j-- {
+		s[j] = s[j-1]
+	}
+	s[0] = el
+	return s
+}
+
+const dynamicReordering = false

--- a/optimize.go
+++ b/optimize.go
@@ -14,4 +14,4 @@ func moveToFront[El any](i int, s []El) []El {
 	return s
 }
 
-const dynamicReordering = false
+const dynamicReordering = true

--- a/time_parse.go
+++ b/time_parse.go
@@ -61,13 +61,15 @@ func tryParseTime(value interface{}) (time.Time, bool) {
 	var t time.Time
 	switch v := value.(type) {
 	case string:
-		for _, layout := range TimeFormats {
-			t, err := time.Parse(layout, v)
+		for i, layout := range TimeFormats {
+			t, err := time.Parse(layout, value.(string))
 			if err == nil {
+				if dynamicReordering {
+					TimeFormats = moveToFront(i, TimeFormats)
+				}
 				t = fixTimebeforeUnixZero(t)
 				return t, true
 			}
-
 		}
 		// try to parse unix time number from string
 		floatVal, err := strconv.ParseFloat(v, 64)

--- a/time_parse_test.go
+++ b/time_parse_test.go
@@ -4,7 +4,54 @@ import (
 	"fmt"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
+
+func TestMoveToFront(t *testing.T) {
+	t.Run("already front", func(t *testing.T) {
+		in := []string{
+			"a",
+			"b",
+			"c",
+		}
+		want := []string{
+			"a",
+			"b",
+			"c",
+		}
+		got := moveToFront(0, in)
+		require.Equal(t, want, got)
+	})
+	t.Run("middle", func(t *testing.T) {
+		in := []string{
+			"a",
+			"b",
+			"c",
+		}
+		want := []string{
+			"b",
+			"a",
+			"c",
+		}
+		got := moveToFront(1, in)
+		require.Equal(t, want, got)
+	})
+	t.Run("last", func(t *testing.T) {
+		in := []string{
+			"a",
+			"b",
+			"c",
+		}
+		want := []string{
+			"c",
+			"a",
+			"b",
+		}
+		got := moveToFront(2, in)
+		require.Equal(t, want, got)
+	})
+}
 
 func TestTimeParseFloat64(t *testing.T) {
 	t.Run("nanoseconds", func(t *testing.T) {


### PR DESCRIPTION
**do not merge** until there's more tests and benchmarks available. 

To add a plethora more matching rules, I suspect that performance will degrade for the least frequently used matchers. The ordering in which we match lines is set at build time, and based on my guess as to which format is seen most often.

I suspect that:
- most program will use the same logging format thorough
- programs that use >1 format (not that uncommon, libraries using their own logger, etc) will still reuse mostly the same few formats
- keeping matchers in the order of their most recent use should work well, as I suspect that the probability of log line N being of format A is highly related to line N-1 also being of format A.