### PR TITLE
fix(update): let the install script do the temp+rename

### DIFF
--- a/internal/pkg/selfupdate/update.go
+++ b/internal/pkg/selfupdate/update.go
@@ -4,10 +4,8 @@ package selfupdate
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
-	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -33,38 +31,16 @@ func UpgradeInPlace(ctx context.Context, curSV semver.Version, baseSiteURL strin
 
 	command := updateCommand(baseSiteURL)
 
-	tmp, err := os.MkdirTemp("", "*")
-	if err != nil {
-		return fmt.Errorf("making temporary directory in order to install new binary: %v", err)
-	}
-	defer os.RemoveAll(tmp)
-
 	cmd := exec.Command(shellToUse, switchToUse, command)
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 	cmd.Stdin = stdin
 	cmd.Env = append(cmd.Env, "INSIDE_HUMANLOG_SELF_UPDATE=true")
-	cmd.Env = append(cmd.Env, fmt.Sprintf("HUMANLOG_INSTALL=%s", tmp))
 	if channelName != nil {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("HUMANLOG_CHANNEL=%s", *channelName))
 	}
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("running update script: %v", err)
-	}
-	currentBinaryPath, err := os.Executable()
-	if err != nil {
-		return fmt.Errorf("getting executable path: %v", err)
-	}
-	newBinaryPath := filepath.Join(tmp, "bin", "humanlog") // command 'install.sh | sh' makes new directory 'bin' under the 'HUMANLOG_INSTALL' path
-	_, err = os.Stat(newBinaryPath)
-	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			return fmt.Errorf("new binary not exists: %v", err)
-		}
-		return fmt.Errorf("stat file at %s: %v", newBinaryPath, err)
-	}
-	if err := os.Rename(newBinaryPath, currentBinaryPath); err != nil {
-		return fmt.Errorf("replace current binary with new one: %v", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Pretty sure this is why https://github.com/humanlogio/humanlog/issues/304 is _still_ broken. Running

```
humanlog version update
```

Ends up having both `humanlog` and the install script, both try to trick each other into installing the binary somewhere and the moving it elsewhere. `humanlog` sets `HUMANLOG_INSTALLDIR` which makes the script install in a weird temp location. Then `humanlog` shells out to the script which runs in its entirety. But the script itself does its own "atomic replacement of the binary" but in a place that `humanlog` doesn't expect. Do the end result is that the update puts the binary in a weird random place, doesn't replace the prior installation, and leads to the old binary still running despite `humanlog onboarding` having run with the new version - and the new version ends up deleted in a temp dir that gets cleaned up.