### PR TITLE
fix(service): do svcHandler nil check before calling close func

### DIFF
--- a/cmd/humanlog/service.go
+++ b/cmd/humanlog/service.go
@@ -92,6 +92,10 @@ func serviceCmd(
 			ctx := getCtx(cctx)
 			ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
 			defer cancel()
+
+			if svcHandler == nil {
+				return nil // service was never started
+			}
 			return svcHandler.close(ctx)
 		},
 		Subcommands: []cli.Command{


### PR DESCRIPTION

https://github.com/user-attachments/assets/cab254da-c063-4d01-b90e-35071f88a1e8

### Steps to Reproduce Panic
1. disable query engine by `humanlog config disable query-engine`
2. restart humanlog service

### Resolution
add `svcHandler` nil pointer check inside `cli.Command.After`